### PR TITLE
Added possibility to send status 'opened'  for a message back to onesignal backend from client source code

### DIFF
--- a/OneSignalSDK/src/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/src/com/onesignal/OneSignal.java
@@ -630,7 +630,7 @@ public class OneSignal {
          runNotificationOpenedCallback(data, false, false);
    }
 
-   private static void sendNotificationOpened(Context inContext, Bundle data) {
+   public static void sendNotificationOpened(Context inContext, Bundle data) {
       try {
          JSONObject customJson = new JSONObject(data.getString("custom"));
          String notificationId = customJson.getString("i");


### PR DESCRIPTION
Hi,

We override our notification handler for GCM  messages because of our requirements. However we would like to have a possibility to send a callback to your server from our code that the message was opened. We can't invoke this method "public static void handleNotificationOpened(Context inContext, Bundle data)" as it forces us to open the app what we don't want to do here".

If you don't want to mark this method as public maybe you would like to change visibility of this method:
"private static String getSavedUserId(Context inContext)". Then we could do a PUT callback on our own but we have to know the player_id.

Thanks in advance.