### PR TITLE
Fixed NPE when no tags available

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -729,7 +729,7 @@ public class OneSignal {
 
    public static void getTags(final GetTagsHandler getTagsHandler) {
       JSONObject tags = OneSignalStateSynchronizer.getTags();
-      if (tags.toString().equals("{}"))
+      if (tags == null || tags.toString().equals("{}"))
          getTagsHandler.tagsAvailable(null);
       else
          getTagsHandler.tagsAvailable(OneSignalStateSynchronizer.getTags());


### PR DESCRIPTION
```
02-15 21:38:30.059 18892-19027/com.my.app E/unknown:React: Exception in native call from JS
                                                                    java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String org.json.JSONObject.toString()' on a null object reference
                                                                        at com.onesignal.OneSignal.getTags(OneSignal.java:732)
                                                                        at com.my.app.reactnativeonesignal.RNOneSignal.getTags(RNOneSignal.java:69)
                                                                        at java.lang.reflect.Method.invoke(Native Method)
                                                                        at java.lang.reflect.Method.invoke(Method.java:372)
                                                                        at com.facebook.react.bridge.BaseJavaModule$JavaMethod.invoke(BaseJavaModule.java:249)
                                                                        at com.facebook.react.bridge.NativeModuleRegistry$ModuleDefinition.call(NativeModuleRegistry.java:158)
                                                                        at com.facebook.react.bridge.NativeModuleRegistry.call(NativeModuleRegistry.java:58)
                                                                        at com.facebook.react.bridge.CatalystInstanceImpl$NativeModulesReactCallback.call(CatalystInstanceImpl.java:431)
                                                                        at com.facebook.react.bridge.queue.NativeRunnableDeprecated.run(Native Method)
                                                                        at android.os.Handler.handleCallback(Handler.java:739)
                                                                        at android.os.Handler.dispatchMessage(Handler.java:95)
                                                                        at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:31)
                                                                        at android.os.Looper.loop(Looper.java:135)
                                                                        at com.facebook.react.bridge.queue.MessageQueueThreadImpl$3.run(MessageQueueThreadImpl.java:185)
                                                                        at java.lang.Thread.run(Thread.java:818)
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/one-signal/onesignal-android-sdk/16)
<!-- Reviewable:end -->
