### PR TITLE
deleteTags, getTags, postNotification, and REST fixes

### DIFF
--- a/OneSignalSDK/app/build.gradle
+++ b/OneSignalSDK/app/build.gradle
@@ -60,7 +60,6 @@ dependencies {
     compile "com.google.android.gms:play-services-location:8.4.0"
 
     testCompile 'junit:junit:4.12'
-//    testCompile 'org.robolectric:shadows-support-v4:3.0'
     testCompile('org.robolectric:robolectric:3.0') {
         exclude group: 'commons-logging', module: 'commons-logging'
         exclude group: 'org.apache.httpcomponents', module: 'httpclient'

--- a/OneSignalSDK/app/src/test/java/com/onesignal/ShadowOneSignalRestClient.java
+++ b/OneSignalSDK/app/src/test/java/com/onesignal/ShadowOneSignalRestClient.java
@@ -36,7 +36,7 @@ public class ShadowOneSignalRestClient {
    public static JSONObject lastPost;
    public static Thread testThread;
    public static boolean failNext, failAll;
-   public static String failResponse = "{}";
+   public static String failResponse = "{}", nextSuccessResponse;
    public static int networkCallCount;
 
    public static final String testUserId = "a2f7f967-e8cc-11e4-bed1-118f05be4511";
@@ -75,7 +75,7 @@ public class ShadowOneSignalRestClient {
       return false;
    }
 
-   static void postSync(String url, JSONObject jsonBody, OneSignalRestClient.ResponseHandler responseHandler) {
+   private static void mockPost(String url, JSONObject jsonBody, OneSignalRestClient.ResponseHandler responseHandler) {
       networkCallCount++;
       lastPost = jsonBody;
 
@@ -88,9 +88,22 @@ public class ShadowOneSignalRestClient {
       else
          retJson = "{\"id\": \"" + testUserId + "\"}";
 
-      responseHandler.onSuccess(retJson);
+      if (nextSuccessResponse != null) {
+         responseHandler.onSuccess(nextSuccessResponse);
+         nextSuccessResponse = null;
+      }
+      else
+         responseHandler.onSuccess(retJson);
 
       safeInterrupt();
+   }
+
+   static void post(String url, JSONObject jsonBody, OneSignalRestClient.ResponseHandler responseHandler) {
+      mockPost(url, jsonBody, responseHandler);
+   }
+
+   static void postSync(String url, JSONObject jsonBody, OneSignalRestClient.ResponseHandler responseHandler) {
+      mockPost(url, jsonBody, responseHandler);
    }
 
    static void putSync(String url, JSONObject jsonBody, OneSignalRestClient.ResponseHandler responseHandler) {

--- a/OneSignalSDK/app/src/test/java/com/test/onesignal/CustomRobolectricTestRunner.java
+++ b/OneSignalSDK/app/src/test/java/com/test/onesignal/CustomRobolectricTestRunner.java
@@ -27,18 +27,30 @@
 
 package com.test.onesignal;
 
+import com.onesignal.example.BuildConfig;
+
 import org.junit.runners.model.InitializationError;
 import org.robolectric.RobolectricGradleTestRunner;
-import org.robolectric.annotation.Config;
 import org.robolectric.internal.bytecode.InstrumentationConfiguration;
 
 public class CustomRobolectricTestRunner extends RobolectricGradleTestRunner {
-    public CustomRobolectricTestRunner(Class<?> klass) throws InitializationError {
-        super(klass);
-    }
+   public CustomRobolectricTestRunner(Class<?> klass) throws InitializationError {
+      super(klass);
 
-    @Override
-    public InstrumentationConfiguration createClassLoaderConfig() {
-        return InstrumentationConfiguration.newBuilder().addInstrumentedPackage("com.onesignal").build();
-    }
+      // Work around for running tests from console.
+      // working directory not being set to $MODULE_DIR$.
+      String buildVariant = (BuildConfig.FLAVOR.isEmpty() ? "" : BuildConfig.FLAVOR + "/") + BuildConfig.BUILD_TYPE;
+      String intermediatesPath = BuildConfig.class.getResource("").toString().replace("file:", "");
+      intermediatesPath = intermediatesPath.substring(0, intermediatesPath.indexOf("/classes"));
+
+      System.setProperty("android.package", BuildConfig.APPLICATION_ID);
+      System.setProperty("android.manifest", intermediatesPath + "/manifests/full/" + buildVariant + "/AndroidManifest.xml");
+      System.setProperty("android.resources", intermediatesPath + "/res/" + buildVariant);
+      System.setProperty("android.assets", intermediatesPath + "/assets/" + buildVariant);
+   }
+
+   @Override
+   public InstrumentationConfiguration createClassLoaderConfig() {
+      return InstrumentationConfiguration.newBuilder().addInstrumentedPackage("com.onesignal").build();
+   }
 }

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -692,7 +692,11 @@ public class OneSignal {
                Log(LOG_LEVEL.DEBUG, "HTTP create notification success: " + (response != null ? response : "null"));
                if (handler != null) {
                   try {
-                     handler.onSuccess(new JSONObject(response));
+                     JSONObject jsonObject = new JSONObject(response);
+                     if (jsonObject.has("errors"))
+                        handler.onFailure(jsonObject);
+                     else
+                        handler.onSuccess(new JSONObject(response));
                   } catch (Throwable t) {
                      t.printStackTrace();
                   }
@@ -728,6 +732,11 @@ public class OneSignal {
    }
 
    public static void getTags(final GetTagsHandler getTagsHandler) {
+      if (appContext == null) {
+         Log(LOG_LEVEL.ERROR, "You must initialize OneSignal before getting tags! Omitting this tag operation.");
+         return;
+      }
+
       JSONObject tags = OneSignalStateSynchronizer.getTags();
       if (tags == null || tags.toString().equals("{}"))
          getTagsHandler.tagsAvailable(null);

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalStateSynchronizer.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignalStateSynchronizer.java
@@ -305,21 +305,22 @@ class OneSignalStateSynchronizer {
             OneSignalStateSynchronizer.generateJsonDiff(syncValues, inSyncValues, syncValues, null);
 
             if (inSyncValues.has("tags")) {
-               JSONObject tags = inSyncValues.optJSONObject("tags");
-               Iterator<String> keys = tags.keys();
+               JSONObject newTags = new JSONObject();
+               JSONObject curTags = inSyncValues.optJSONObject("tags");
+               Iterator<String> keys = curTags.keys();
                String key;
 
-               while (keys.hasNext()) {
-                  key = keys.next();
-                  if ("".equals(tags.optString(key)))
-                     tags.remove(key);
-               }
-
                try {
-                  if (tags.toString().equals("{}"))
+                  while (keys.hasNext()) {
+                     key = keys.next();
+                     if (!"".equals(curTags.optString(key)))
+                        newTags.put(key, curTags.optString(key));
+                  }
+
+                  if (newTags.toString().equals("{}"))
                      syncValues.remove("tags");
                   else
-                     syncValues.put("tags", tags);
+                     syncValues.put("tags", newTags);
                } catch (Throwable t) {}
             }
          }


### PR DESCRIPTION
* Fixed bug where deleting multiple already sync tags after sync would print a null error and local sync state would not save.
* Now checks for "errors" key and fires onFailure correctly in postNotification.
* getTags no longer throws null exception if called before OneSignal init is called.
* Improved non 200 OK response handling in the REST Client.
* Robolectric tests are now runnable from the command line / terminal and execute much faster.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/one-signal/onesignal-android-sdk/24)
<!-- Reviewable:end -->
