### PR TITLE
Added method to disable showing notifications

### DIFF
--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/NotificationBundleProcessor.java
@@ -56,6 +56,8 @@ public class NotificationBundleProcessor {
 
          BackgroundBroadcaster.Invoke(context, bundle, isActive);
 
+         if (OneSignal.getPreventDisplayingNotificationEnabled(context)) return;
+
          if (!bundle.containsKey("alert") || bundle.getString("alert") == null || bundle.getString("alert").equals(""))
             return;
 

--- a/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
+++ b/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java
@@ -1151,6 +1151,20 @@ public class OneSignal {
       return prefs.getBoolean("ONESIGNAL_INAPP_ALERT", false);
    }
 
+   public static void preventDisplayingNotification(boolean enable) {
+      if (appContext == null)
+         return;
+      final SharedPreferences prefs = getGcmPreferences(appContext);
+      SharedPreferences.Editor editor = prefs.edit();
+      editor.putBoolean("ONESIGNAL_PREVENT_DISPLAYING", enable);
+      editor.commit();
+   }
+
+   static boolean getPreventDisplayingNotificationEnabled(Context context) {
+      final SharedPreferences prefs = getGcmPreferences(context);
+      return prefs.getBoolean("ONESIGNAL_PREVENT_DISPLAYING", false);
+   }
+
    public static void setSubscription(boolean enable) {
       if (appContext == null) {
          Log(LOG_LEVEL.ERROR, "OneSignal.init has not been called. Could not set subscription.");


### PR DESCRIPTION
I want to prevent a notification that is sent with content from being displayed because I want to handle it in the background receiver. I've added a method that allows disabling the notifications that have content from being displayed. This is done via a flag in shared preferences.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/one-signal/onesignal-android-sdk/32)
<!-- Reviewable:end -->
